### PR TITLE
PLAT-10154 Add Shortcode to trigger add to car modal for LPs and Course

### DIFF
--- a/includes/acf/weblink-settings.php
+++ b/includes/acf/weblink-settings.php
@@ -642,7 +642,10 @@ if (function_exists('acf_add_local_field_group')) :
 [administrate-widget type="EventList" location_name="NAME"]
 [administrate-widget type="EventList" date_filter="false" location_filter="false" course_filter="false" category_filter="false"]
 
-[administrate-widget type=\'Catalogue\' catalogue_type=\'course\' date_filter=\'true\' location_filter=\'true\' course_filter=\'true\' category_filter=\'true\' event_title=\'true\' event_location=\'true\' event_venue=\'true\' event_start_date=\'true\' event_duration=\'true\' event_time=\'true\' event_places_remaining=\'true\' event_price=\'true\' event_addtocart=\'true\' classroom_start_date=\'true\' classroom_duration=\'true\' classroom_time=\'true\' lms_start_date=\'true\' lms_duration=\'true\' lms_time=\'true\']',
+[administrate-widget type=\'Catalogue\' catalogue_type=\'course\' date_filter=\'true\' location_filter=\'true\' course_filter=\'true\' category_filter=\'true\' event_title=\'true\' event_location=\'true\' event_venue=\'true\' event_start_date=\'true\' event_duration=\'true\' event_time=\'true\' event_places_remaining=\'true\' event_price=\'true\' event_addtocart=\'true\' classroom_start_date=\'true\' classroom_duration=\'true\' classroom_time=\'true\' lms_start_date=\'true\' lms_duration=\'true\' lms_time=\'true\']
+
+  [admwswp-addToCart path_id="Path ID" class=""]
+  [admwswp-addToCart course_id="Course ID" class=""]',
       'new_lines' => 'wpautop',
       'esc_html' => 0,
     ),

--- a/includes/class-admwswp.php
+++ b/includes/class-admwswp.php
@@ -193,6 +193,8 @@ class Admwswp
         $this->loader->add_action('wp_enqueue_scripts', $plugin_public, 'enqueue_scripts');
 
         $this->loader->add_shortcode('administrate-widget', $plugin_public, 'weblinkWidget');
+
+        $this->loader->add_shortcode('admwswp-addToCart', $plugin_public, 'addToCart');
     }
 
     /**

--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -55,6 +55,37 @@ class Admwswp_Public
         $this->version = $version;
     }
 
+    public static function addToCart($attr)
+    {
+        if (is_admin()) {
+            return;
+        }
+
+        extract(
+            shortcode_atts(
+                array(
+                    'path_id' => '',
+                    'course_id' => '',
+                    'class' => 'btn btn-lg btn-primary',
+                ),
+                $attr
+            )
+        );
+
+        if ($path_id) {
+            $data = "data-path_id=" . $path_id;
+        }
+
+        if ($course_id) {
+            $data = "data-course_id=" . $course_id;
+        }
+
+        $html = "<div class='admwswp-addToCart $class' $data>";
+        $html .= __('Add to Cart', 'admwswp');
+        $html .= "</div>";
+        return $html;
+    }
+
     public static function weblinkWidget($attr)
     {
 
@@ -241,13 +272,13 @@ class Admwswp_Public
             'all'
         );
 
-        // wp_enqueue_style(
-        //     $this->plugin_name . '-public',
-        //     plugin_dir_url(__FILE__) . 'css/admwswp-public.css',
-        //     array(),
-        //     $this->version,
-        //     'all'
-        // );
+        wp_enqueue_style(
+            $this->plugin_name . '-public',
+            plugin_dir_url(__FILE__) . 'css/admwswp-public.css',
+            array(),
+            $this->version,
+            'all'
+        );
 
         $portalAddress = get_field('portalAddress', 'options');
 
@@ -305,13 +336,13 @@ class Admwswp_Public
             true
         );
 
-        // wp_enqueue_script(
-        //     $this->plugin_name . '-public',
-        //     plugin_dir_url(__FILE__) . 'js/admwswp-public.js',
-        //     array( 'jquery' ),
-        //     $this->version,
-        //     false
-        // );
+        wp_enqueue_script(
+            $this->plugin_name . '-public',
+            plugin_dir_url(__FILE__) . 'js/admwswp-public.js',
+            array( 'jquery' , $this->plugin_name . '-weblink'),
+            $this->version,
+            false
+        );
 
         wp_add_inline_script(
             $this->plugin_name . '-weblink',

--- a/public/css/admwswp-public.css
+++ b/public/css/admwswp-public.css
@@ -2,4 +2,6 @@
  * All of the CSS for your public-facing functionality should be
  * included in this file.
  */
-
+.admwswp-addToCart {
+  cursor: pointer;
+}

--- a/public/js/admwswp-public.js
+++ b/public/js/admwswp-public.js
@@ -1,31 +1,18 @@
 jQuery(function($) {
-
-	/**
-	 * All of the code for your public-facing JavaScript source
-	 * should reside in this file.
-	 *
-	 * Note: It has been assumed you will write jQuery code here, so the
-	 * $ function reference has been prepared for usage within the scope
-	 * of this function.
-	 *
-	 * This enables you to define handlers, for when the DOM is ready:
-	 *
-	 * $(function() {
-	 *
-	 * });
-	 *
-	 * When the window is loaded:
-	 *
-	 * $( window ).load(function() {
-	 *
-	 * });
-	 *
-	 * ...and/or other possibilities.
-	 *
-	 * Ideally, it is not considered best practise to attach more than a
-	 * single DOM-ready or window-load handler for a particular page.
-	 * Although scripts in the WordPress core, Plugins and Themes may be
-	 * practising this, we should strive to set a better example in our own work.
-	 */
-
+	$(document).ready(function () {
+		$('.admwswp-addToCart', 'body').on('click', function(){
+			if (weblink !== undefined) {
+				var pathId = $(this).data('path_id');
+				if (pathId) {
+					weblink.stores.STORE_PATH_PICKER.setPathId(pathId);
+					weblink.stores.STORE_DETAILS.openAddPathToCart();
+				}
+				var courseId = $(this).data('course_id');
+				if (courseId) {
+					weblink.stores.STORE_EVENT_PICKER.setCourseId(courseId);
+					weblink.stores.STORE_DETAILS.openAddToCart();
+				}
+			}
+		});
+	});
 });


### PR DESCRIPTION
In this PR we are adding a shortcode to be used to trigger adding courses or LPs to the cart. by triggering the modal to select location / price levels exc...
Example Shortcodes: `[admwswp-addToCart path_id='$tmsId' class='book-now-btn']` or `[admwswp-addToCart course_id='$tmsId' class='book-now-btn']`
https://administrate.atlassian.net/browse/PLAT-10154