### PR TITLE
PS-2942 add ability to hide edit button

### DIFF
--- a/admin/class-admwswp-admin.php
+++ b/admin/class-admwswp-admin.php
@@ -83,6 +83,9 @@ class Admwswp_Admin
                 unset($attr['screen_size']);
             break;
             case 'Cart':
+                $hideEditButton = $attr['edit_button'];
+                return "[administrate-widget type='$type' hide_edit_button='$hideEditButton']";
+                break;
             case 'SearchBar':
             case 'CategoryDropdown':
             case 'GiftVoucherBalance':
@@ -282,6 +285,10 @@ class Admwswp_Admin
                     'lms_time' => array(
                         'type' => 'bool',
                         'default' => get_field('showLmsTimeColumn', 'options')
+                    ),
+                    'edit_button' => array(
+                        'type' => 'bool',
+                        'default' => get_field('cartHideEditButton', 'options')
                     ),
                 )
             )

--- a/admin/js/editor-blocks.js
+++ b/admin/js/editor-blocks.js
@@ -42,6 +42,7 @@ registerBlockType(
 						var sorting = jQuery('.admwswp-sorting');
 						var filters = jQuery('.admwswp-filters');
 						var columns = jQuery('.admwswp-columns');
+						var cartOptions = jQuery('.admwswp-cart-options');
 
 						catalogueType.addClass('hidden');
 						category.addClass('hidden');
@@ -53,6 +54,7 @@ registerBlockType(
 						filters.addClass('hidden');
 						columns.addClass('hidden');
 						pagerType.addClass('hidden');
+						cartOptions.addClass('hidden');
 
 						if ('Catalogue' === value) {
 							catalogueType.removeClass('hidden');
@@ -92,6 +94,10 @@ registerBlockType(
 							sorting.removeClass('hidden');
 							filters.removeClass('hidden');
 							columns.removeClass('hidden');
+						}
+
+						if ('Cart' === value) {
+							cartOptions.removeClass('hidden');
 						}
 				}
 
@@ -562,6 +568,29 @@ registerBlockType(
 											}
 										)
 
+									]
+								),
+								createElement(
+									PanelBody,
+									{
+										title: "Cart Options",
+										initialOpen: false,
+										className: 'admwswp-cart-options',
+										icon: 'columns'
+									},
+									[
+										createElement(
+											ToggleControl,
+											{
+												className: 'admwswp-edit_button',
+												label: __('Hide Edit Button'),
+												checked: attributes.edit_button,
+												onChange: (value) => {
+													setAttributes({edit_button: value});
+												},
+												type: 'bool',
+											}
+										)
 									]
 								),
 

--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -133,6 +133,7 @@ class Admwswp_Public
                     'screen_size' => 'desktop',
                     'pager_type' => 'loadMore',
                     'show_cart_buttons'=> false,
+                    'hide_edit_button' => false,
                 ),
                 $attr
             )
@@ -141,6 +142,9 @@ class Admwswp_Public
         $webLinkArgs = array();
 
         switch ($type) {
+            case 'Cart':
+                $webLinkArgs['hideEditItemButton'] = filter_var($hide_edit_button, FILTER_VALIDATE_BOOLEAN);
+                break;
             case 'Basket':
                 $webLinkArgs['showBasketPopover'] = filter_var($show_basket_popover, FILTER_VALIDATE_BOOLEAN);
                 if ($cart_url) {


### PR DESCRIPTION
In this PR we are adding the ability to select to hide the cart edit buttons on the cart widget.
now  the shortcode has an attribute "hideEditButton" with true or false as values.
Also on the frontend we are handling fetching the attribute value and using it in the `weblink.mount()` method

https://administrate.atlassian.net/browse/PS-2942