### PR TITLE
PS-3518 Fix addToCart button shortcode to work in Ajax calls

### DIFF
--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -57,10 +57,6 @@ class Admwswp_Public
 
     public static function addToCart($attr)
     {
-        if (is_admin()) {
-            return;
-        }
-
         extract(
             shortcode_atts(
                 array(
@@ -177,7 +173,7 @@ class Admwswp_Public
                     $webLinkArgs['showCartButtons'] = filter_var($show_cart_buttons, FILTER_VALIDATE_BOOLEAN);
                     $webLinkArgs['showRemainingPlacesFilter'] = filter_var($show_remaining_places_filter, FILTER_VALIDATE_BOOLEAN);
                     $webLinkArgs['minimumRemainingPlaces'] = $minimum_places_remaining;
-                    if($locations) {
+                    if ($locations) {
                         $webLinkArgs['location'] = $locations;
                     }
                     $webLinkArgs['showLocationFilter'] = filter_var($location_filter, FILTER_VALIDATE_BOOLEAN);

--- a/public/js/admwswp-public.js
+++ b/public/js/admwswp-public.js
@@ -1,6 +1,9 @@
 jQuery(function($) {
 	$(document).ready(function () {
-		$('.admwswp-addToCart', 'body').on('click', function(){
+		$('body').on(
+			'click',
+			'.admwswp-addToCart',
+			function(){
 			if (weblink !== undefined) {
 				var pathId = $(this).data('path_id');
 				if (pathId) {


### PR DESCRIPTION
Prior to this the addToCart shortcode only worked on front end, and using it in ajax calls (wordpress admin) was not working as intended.
With those changes the addToCart shortcode now works on front end and in ajax calls to render the button using the do_shortcode core method.
https://administrate.atlassian.net/browse/PS-3518