### PR TITLE
PLAT-14776 Hide Event's Add To Cart Button When Cart is Disabled

### DIFF
--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -129,7 +129,7 @@ class Admwswp_Public
                     'cart_url' => '',
                     'screen_size' => 'desktop',
                     'pager_type' => 'loadMore',
-                    'show_cart_buttons' => false,
+                    'show_cart_buttons' => true,
                     'hide_edit_button' => false,
                     'show_time_zone' => true,
                     'more_filter' => false,
@@ -180,6 +180,9 @@ class Admwswp_Public
                         $webLinkArgs['location'] = $locations;
                     }
                     $webLinkArgs['showLocationFilter'] = filter_var($location_filter, FILTER_VALIDATE_BOOLEAN);
+
+                    // Override showCartButtons based on showAddToCart option
+                    $webLinkArgs['showCartButtons'] = get_field('showAddToCart', 'options');
                 }
                 break;
             case 'CourseDetails':

--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -118,7 +118,7 @@ class Admwswp_Public
                     'event_time' => false,
                     'event_places_remaining' => false,
                     'event_price' => false,
-                    'event_addtocart' => false,
+                    'event_addtocart' => true,
                     'classroom_start_date' => false,
                     'classroom_duration' => false,
                     'classroom_time' => false,
@@ -278,6 +278,10 @@ class Admwswp_Public
                 $webLinkArgs['pagerType'] = $pager_type;
                 $webLinkArgs['showTimezone'] = filter_var($show_time_zone, FILTER_VALIDATE_BOOLEAN);
                 $webLinkArgs['showLocale'] = filter_var($show_locale, FILTER_VALIDATE_BOOLEAN);
+
+                // Override showAddToCartColumn based on showAddToCart option
+                $webLinkArgs['showAddToCartColumn'] = get_field('showAddToCart', 'options');
+
                 break;
             default:
                 break;


### PR DESCRIPTION
In this PR:
1. Adding an override to the showAddToCartColumn set in the short-code flag using the global showAddToCart option
2. Adding an override to the Override the showCartButtons set in the short-code flag using the global showAddToCart option
We are doing those overrides to totally disable any user interaction with weblink cart / checkout.
https://administrate.atlassian.net/browse/PLAT-14776