### PR TITLE
PLAT-14774 Disable/Override custom add to cart button shortcode based on showAddToCart option value

### DIFF
--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -57,6 +57,10 @@ class Admwswp_Public
 
     public static function addToCart($attr)
     {
+        if (!get_field('showAddToCart', 'options')) {
+            return '';
+        }
+
         extract(
             shortcode_atts(
                 array(


### PR DESCRIPTION
In this PR we are disabling/enabling the custom add to cart button short-code based on the showAddToCart global settings option value.
If ON the short-code will render that add to cart button if OFF the short-code will return an empty string and no button will be visible on the page.
https://administrate.atlassian.net/browse/PLAT-14774