### PR TITLE
PLAT-14774 Add event Request Popup Shortcode

### DIFF
--- a/includes/class-admwswp.php
+++ b/includes/class-admwswp.php
@@ -189,6 +189,7 @@ class Admwswp
         $this->loader->add_shortcode('administrate-widget', $plugin_public, 'weblinkWidget');
 
         $this->loader->add_shortcode('admwswp-addToCart', $plugin_public, 'addToCart');
+        $this->loader->add_shortcode('admwswp-eventRequest', $plugin_public, 'eventRequest');
 
         $this->loader->add_filter('clean_url', $plugin_public, 'add_async_forscript');
     }

--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -80,9 +80,43 @@ class Admwswp_Public
             $data = "data-course_id=" . $course_id;
         }
 
-        $html = "<div class='admwswp-addToCart $class' $data>";
+        $html = "<div class='admwswp-btn admwswp-addToCart admwswp-waitWeblink $class' $data>";
         $html .= __('Add to Cart', 'admwswp');
         $html .= "</div>";
+        return $html;
+    }
+
+    public static function eventRequest($attr)
+    {
+        extract(
+            shortcode_atts(
+                array(
+                    'button_text' => __('Request Training', 'admwswp'),
+                    'tms_id' => '',
+                    'wrapper_id' => 'admwswp-eventRequestPopup',
+                    'class' => 'btn btn-lg btn-primary',
+                    'popup_title' => __('Request Training', 'admwswp'),
+                    'popup_class' => 'admwswp-dialog',
+                ),
+                $attr
+            )
+        );
+        $html = "";
+        if ($tms_id && $wrapper_id) {
+            $data = "data-tms_id=" . $tms_id;
+            $data .= " data-wrapper_id='" . $wrapper_id . "'";
+            $data .= " data-popup_title='" . $popup_title . "'";
+            $data .= " data-popup_class='" . $popup_class . "'";
+
+            $html = "
+            <div class='admwswp-btn admwswp-eventRequest admwswp-waitWeblink $class' $data>$button_text</div>
+            <div class='admwswp-eventRequestPopup' id=$wrapper_id>
+                <div class='admwswp-loader fa-3x text-center'>
+                    <i class='fas fa-circle-notch fa-spin'></i>
+                </div>
+            </div>
+            ";
+        }
         return $html;
     }
 

--- a/public/css/admwswp-public.css
+++ b/public/css/admwswp-public.css
@@ -2,10 +2,61 @@
  * All of the CSS for your public-facing functionality should be
  * included in this file.
  */
-.admwswp-addToCart {
+.admwswp-loader {
+  display: none;
+  visibility: hidden;
+}
+
+.admwswp-btn.admwswp-waitWeblink {
+  opacity: 0.8;
+}
+
+.admwswp-btn.admwswp-waitWeblink.btn,
+.admwswp-btn.admwswp-waitWeblink.btn:hover {
+  background-color: #6c757d;
+  cursor: default;
+}
+
+.admwswp-btn {
   cursor: pointer;
 }
 
 .weblink-Basket-container .fas {
   font-size: 25px
+}
+
+.admwswp-dialog {
+  border: 0px;
+}
+
+.admwswp-dialog .ui-dialog-titlebar {
+  border: 0px;
+  border-bottom: 1px solid black;
+  border-radius: 0px;
+  height: 2em;
+}
+
+.admwswp-dialog .ui-dialog-titlebar .ui-dialog-title {
+  line-height: 1.2em;
+  margin: 0px;
+}
+
+.admwswp-dialog .ui-dialog-titlebar-close {
+  background: none;
+  border: 0px;
+  outline: none;
+}
+
+.admwswp-dialog .ui-dialog-titlebar-close::before {
+  line-height: 1em;
+}
+
+.admwswp-dialog .admwswp-eventRequestPopup .admwswp-loader {
+  display: block;
+  visibility: visible;
+}
+
+.admwswp-dialog .admwswp-eventRequestPopup .training-request-form-container {
+  width: 100%;
+  margin: 0px;
 }

--- a/public/js/admwswp-public.js
+++ b/public/js/admwswp-public.js
@@ -1,21 +1,108 @@
 jQuery(function($) {
+
+	var waitWeblinkClass = 'admwswp-waitWeblink';
+
+	function isActiveWeblink() {
+		return !!weblink;
+	}
+
+	function removeWaitWeblinkClass() {
+		$('.' + waitWeblinkClass, 'body').removeClass(waitWeblinkClass);
+	}
+
+	function checkIfweblinkIsLoaded() {
+		var weblinkInterval = setInterval(function() {
+			if (isActiveWeblink()) {
+				removeWaitWeblinkClass();
+				clearInterval(weblinkInterval);
+			}
+		}, 200);
+	}
+
+	$(document).ajaxComplete(function(event,request, settings){
+		if($('.' + waitWeblinkClass).length > 0) {
+			if (isActiveWeblink()) {
+			 	removeWaitWeblinkClass();
+			} else {
+				checkIfweblinkIsLoaded();
+			}
+		}
+	});
+
+	function addToCart (element) {
+
+		if (element.hasClass(waitWeblinkClass) || !weblink) {
+			return;
+		}
+
+		var pathId = element.data('path_id');
+		if (pathId) {
+			weblink.stores.STORE_PATH_PICKER.setPathId(pathId);
+			weblink.stores.STORE_DETAILS.openAddPathToCart();
+		}
+		var courseId = element.data('course_id');
+		if (courseId) {
+			weblink.stores.STORE_EVENT_PICKER.setCourseId(courseId);
+			weblink.stores.STORE_DETAILS.openAddToCart();
+		}
+
+	}
+
+	function eventRequestPopup (element) {
+
+		if (element.hasClass(waitWeblinkClass) || !weblink) {
+			return;
+		}
+
+		var tms_id = element.data('tms_id');
+		var wrapper_id = element.data('wrapper_id');
+		var popup_title = element.data('popup_title');
+		var popup_class = element.data('popup_class');
+		if (tms_id && wrapper_id) {
+			$("#" + wrapper_id).dialog(
+				{
+					modal: true,
+					title: popup_title,
+					dialogClass: popup_class,
+					closeOnEscape: true,
+					height: 'auto',
+					minHeight: 500,
+					width: 400,
+					resizable: false,
+					draggable: false,
+					open: function(event, ui) {
+						$(event.target).dialog('widget')
+						.css({ position: 'fixed' })
+						.position({ my: 'center', at: 'center', of: window });
+						weblink.mount(document.getElementById(wrapper_id),"TrainingRequest",{"interestId":tms_id});
+					},
+				}
+			);
+		}
+	}
+
 	$(document).ready(function () {
+
+		if($('.' + waitWeblinkClass).length > 0) {
+			checkIfweblinkIsLoaded();
+		}
+
 		$('body').on(
 			'click',
 			'.admwswp-addToCart',
 			function(){
-			if (weblink !== undefined) {
-				var pathId = $(this).data('path_id');
-				if (pathId) {
-					weblink.stores.STORE_PATH_PICKER.setPathId(pathId);
-					weblink.stores.STORE_DETAILS.openAddPathToCart();
-				}
-				var courseId = $(this).data('course_id');
-				if (courseId) {
-					weblink.stores.STORE_EVENT_PICKER.setCourseId(courseId);
-					weblink.stores.STORE_DETAILS.openAddToCart();
-				}
+				addToCart($(this));
 			}
-		});
+		);
+
+		$('body').on(
+			'click',
+			'.admwswp-eventRequest',
+			function(){
+				eventRequestPopup($(this));
+			}
+		);
+
 	});
+
 });


### PR DESCRIPTION
In the PR we are adding a new custom short-code `admwswp-eventRequest` to render a button that opens a modal with an event request form for a particular Course or LP by TMS ID
This new Short-code will be used for Maersk in the bundled LPs Listing and on the Course template pages on the website if the Portal is configured to disable Cart / Checkout and only accept event request forms.