### PR TITLE
PLAT-24017 Can use configuration from Weblink Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ if (! defined('ADMWSWP_WEBLINK_ENV')) {
 This plugin skeleton and file structure is generated using the [WordPress plugin boilerplate generator](https://wppb.me/).
 
 ## Changelog
+###### 1.6.2
+* Add `product_route` which allows catalogue cards to automatically link to https://{YOUR_WEBSITE}/{THIS_ROUTE}/product-name-with-dashes instead of using embedded navigation
+* Add `configuration` which overrides all other configuration options on the shortcode. This can be used to copy and paste a WebLink Widget configuration from [WebLink Builder](https://weblink-builder.getadministrate.com/) and use it in WordPress
+
 
 ###### 1.6.1
 * Add timeout before triggering add to cart weblink popup.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ This short-code handles all Weblink widget types based on the provided `type` so
 
 # Developers Section
 
+## Setup
+The project includes a Dockerized setup for WordPress which can be started by running the following command from the project root:
+```bash
+docker-compose up -d
+```
+
+You can then go to http://localhost:8888 to set up your WordPress site.
+
+Once your WordPress site is set up, you will need to install and activate the [Plugin Dependencies](#dependencies). Once these are activated, you can activate this Plugin (*Administrate Weblink2 Shortcodes*).
+
 ## Custom Filters
 
 ### Assets Management

--- a/admin/class-admwswp-admin.php
+++ b/admin/class-admwswp-admin.php
@@ -185,6 +185,10 @@ class Admwswp_Admin
                         'type' => 'string',
                         'default' => 'Catalogue'
                     ),
+                    'configuration' => array(
+                        'type' => 'string',
+                        'default' => ''
+                    ),
                     'catalogue_type' => array(
                         'type' => 'string',
                         'default' => 'All'
@@ -192,6 +196,10 @@ class Admwswp_Admin
                     'pager_type' => array(
                         'type' => 'string',
                         'default' => 'loadMore'
+                    ),
+                    'product_route' => array(
+                        'type' => 'string',
+                        'default' => ''
                     ),
                     'category_id' => array(
                         'type' => 'string',

--- a/admin/js/editor-blocks.js
+++ b/admin/js/editor-blocks.js
@@ -9,6 +9,7 @@ const {
 	CheckboxControl,
 	RadioControl,
 	ToggleControl,
+	TextareaControl,
 	Panel,
 	PanelBody,
 	PanelRow
@@ -29,12 +30,13 @@ registerBlockType(
   			jQuery('.wp-block[data-type="admwswp/weblink"]').on('focus', function(){
   				var type = jQuery('.admwswp-widget-type select').val();
   				updateSections(type);
-  			});
+				});
 
 				function updateSections(value) {
 					  var catalogueType = jQuery('.admwswp-catalogue-type');
 					  var pagerType = jQuery('.admwswp-pager-type');
 						var category = jQuery('.admwswp-catalogue-category');
+						var productRoute = jQuery(".admwswp-product-route");
 						var path = jQuery('.admwswp-path');
 						var course = jQuery('.admwswp-course');
 						var location = jQuery('.admwswp-location');
@@ -59,6 +61,7 @@ registerBlockType(
 						cartOptions.addClass('hidden');
 						eventsListOptions.addClass('hidden');
 						trainingRequest.addClass('hidden');
+						productRoute.addClass('hidden');
 
 						if ('TrainingRequest' === value) {
 							trainingRequest.removeClass('hidden');
@@ -71,6 +74,7 @@ registerBlockType(
 							filters.removeClass('hidden');
 							columns.removeClass('hidden');
 							pagerType.removeClass('hidden');
+							productRoute.removeClass('hidden');
 						}
 
 						if ('CourseDetails' === value) {
@@ -166,6 +170,18 @@ registerBlockType(
 											}
 										),
 										createElement(
+											TextareaControl,
+											{
+												className: 'admwswp-widget-configuration',
+												value: attributes.configuration,
+												label: __('Configuration'),
+												help: __('Build a WebLink Widget on WebLink Builder and paste the configuration in here. This overrides all other configuration options.'),
+												onChange: (value) => {
+													setAttributes({configuration: value});
+												},
+											}
+										),
+										createElement(
 											SelectControl,
 											{
 												className: 'admwswp-catalogue-type',
@@ -196,6 +212,19 @@ registerBlockType(
 													{value: 'loadMore', label: 'Load More'},
 													{value: 'full', label: 'Full Pager'},
 												],
+											}
+										),
+										createElement(
+											TextControl,
+											{
+												className: 'admwswp-product-route',
+												value: attributes.product_route,
+												label: __('Product Route'),
+												help: __('When defined, catalogue cards will automatically link to https://{YOUR_WEBSITE}/{THIS_ROUTE}/product-name-with-dashes instead of using embedded navigation.'),
+												onChange: (value) => {
+													setAttributes({ product_route: value });
+												},
+												type: 'text',
 											}
 										),
 										createElement(

--- a/admwswp.php
+++ b/admwswp.php
@@ -34,7 +34,7 @@ if (! defined('ADMWSWP_WEBLINK_ENV')) {
     define('ADMWSWP_WEBLINK_ENV', 'prod'); // prod or staging
 }
 
-define('ADMWSWP_VERSION', '1.6.1');
+define('ADMWSWP_VERSION', '1.6.2');
 define('ADMWSWP_TEXTDOMAIN', 'admwswp');
 define('ADMWSWP_PLUGIN_NAME', 'administrate-wp-weblink-plugin/admwswp.php');
 // List of plugins separated by comas.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+  db:
+    platform: linux/x86_64
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: somewordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  wordpress:
+    depends_on:
+      - db
+    build: ./docker/wordpress
+    volumes:
+      - wordpress_data:/var/www/html
+      - ./docker/wordpress/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
+      - .:/var/www/html/wp-content/plugins/widgets_plugin
+    ports:
+      - "8888:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DEBUG: 0
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+volumes:
+  db_data: {}
+  wordpress_data: {}

--- a/docker/wordpress/Dockerfile
+++ b/docker/wordpress/Dockerfile
@@ -1,0 +1,6 @@
+FROM wordpress:5
+
+EXPOSE 80
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/docker/wordpress/uploads.ini
+++ b/docker/wordpress/uploads.ini
@@ -1,0 +1,5 @@
+file_uploads = On
+memory_limit = 500M
+upload_max_filesize = 500M
+post_max_size = 500M
+max_execution_time = 600

--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -181,6 +181,7 @@ class Admwswp_Public
                     'show_remaining_places_filter' => false,
                     'id' => '',
                     'show_locale' => false,
+                    'configuration' => '',
                 ),
                 $attr
             )
@@ -258,9 +259,6 @@ class Admwswp_Public
                     $webLinkArgs['fromDate'] = $from_date;
                 }
 
-                if ($to_date) {
-                    $webLinkArgs['toDate'] = $to_date;
-                }
                 if ($to_date) {
                     $webLinkArgs['toDate'] = $to_date;
                 }
@@ -363,7 +361,9 @@ class Admwswp_Public
             'onObjectiveSelection' => '',
         ];
         $weblinkMountArgs = apply_filters('admwswp_weblink_args', $weblinkMountArgs);
-        if ($weblinkMountArgs['args']) {
+        if ($configuration !== '') {
+            $html .= "," . $configuration;
+        } else if ($weblinkMountArgs['args']) {
             $webLinkArgsJson = json_encode($weblinkMountArgs['args']);
             $html .= "," . $webLinkArgsJson;
         }


### PR DESCRIPTION
This change adds the ability to specify the `configuration` and `product_route` arguments for the `[administrate-widget]` shortcode. The `configuration` argument will allow users to take a JSON configuration string from WebLink Builder and use it directly in the shortcode. This will override any other arguments given to the shortcode. The `product_route` argument can be used to specify a link builder function for the Catalogue widget using that `product_route` and the products name in kebab-case (e.g. if the `product_route` is `/foo`, Course Bar would be available at `https://mywebsite.test/foo/course-bar`). If the `configuration` argument defines the `links` object, then the `product_route` is ignored.

Both of these arguments can be configured using controls in the Weblink2 Widget block editor UI, which also allows us to show help messages to users explaining what each control does.

https://administrate.atlassian.net/browse/PLAT-24017