### PR TITLE
PLAT-24370: Fix shortcode square bracket configuration

### DIFF
--- a/admin/js/editor-blocks.js
+++ b/admin/js/editor-blocks.js
@@ -177,7 +177,14 @@ registerBlockType(
 												label: __('Configuration'),
 												help: __('Build a WebLink Widget on WebLink Builder and paste the configuration in here. This overrides all other configuration options.'),
 												onChange: (value) => {
-													setAttributes({configuration: value});
+													var updatedValue = value.replace(/\[|\]/g, (char) => {
+														if (char === '[') {
+															return '&#91;';
+														}
+														return '&#93;';
+													});
+													var attributes = {configuration: updatedValue};
+													setAttributes(attributes);
 												},
 											}
 										),

--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -388,6 +388,7 @@ class Admwswp_Public
         ];
         $weblinkMountArgs = apply_filters('admwswp_weblink_args', $weblinkMountArgs);
         if ($configuration !== '') {
+            $configuration = str_replace(["&#091;", "&#093;"], ["[", "]"], $configuration);
             $decodedConfiguration = json_decode($configuration, true);
 
             if ($decodedConfiguration['links'] || !$product_route) {


### PR DESCRIPTION
When pasting a configuration that included an array, Wordpress was interpreting this as the end of the shortcode instead of the array. The configuration now replaces the `[` and `]` characters with the ASCII codes when they are pasted into the configuration box and then replaced back before they are converted to JSON in the PHP.

https://administrate.atlassian.net/browse/PLAT-24370