### PR TITLE
PLAT-24526 - Fix encoding single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ docker-compose up -d
 
 You can then go to http://localhost:8888 to set up your WordPress site.
 
+By default, we are pointing at production for things like Portal Auth, this can be changed in `admwswp.php` where we define `ADMWSWP_WEBLINK_ENV`.
+
 Once your WordPress site is set up, you will need to install and activate the [Plugin Dependencies](#dependencies). Once these are activated, you can activate this Plugin (*Administrate Weblink2 Shortcodes*).
 
 ## Custom Filters
@@ -204,6 +206,9 @@ if (! defined('ADMWSWP_WEBLINK_ENV')) {
 This plugin skeleton and file structure is generated using the [WordPress plugin boilerplate generator](https://wppb.me/).
 
 ## Changelog
+###### 1.6.4
+* Fix parsing widget configurations with single quotes by replacing them with the corresponding ASCII codes to prevent the shortcode being cut-off early by Wordpress. Fix parsing widget configurations with `&` replacing them with `&amp;` to work around a bug in WPTexturize.
+
 ###### 1.6.3
 * Fix parsing widget configurations with arrays by replacing `[]` characters with their corresponding ASCII codes to prevent the shortcode being escaped early by Wordpress.
 

--- a/admin/js/editor-blocks.js
+++ b/admin/js/editor-blocks.js
@@ -177,11 +177,16 @@ registerBlockType(
 												label: __('Configuration'),
 												help: __('Build a WebLink Widget on WebLink Builder and paste the configuration in here. This overrides all other configuration options.'),
 												onChange: (value) => {
-													var updatedValue = value.replace(/\[|\]/g, (char) => {
+													var updatedValue = value.replace(/\[|\]|[']/g, (char) => {
 														if (char === '[') {
 															return '&#91;';
 														}
-														return '&#93;';
+														if (char === ']') {
+															return '&#93;';
+														}
+														if (char === "'") {
+															return '&#39;';
+														}
 													});
 													var attributes = {configuration: updatedValue};
 													setAttributes(attributes);

--- a/admwswp.php
+++ b/admwswp.php
@@ -34,7 +34,7 @@ if (! defined('ADMWSWP_WEBLINK_ENV')) {
     define('ADMWSWP_WEBLINK_ENV', 'prod'); // prod or staging
 }
 
-define('ADMWSWP_VERSION', '1.6.3');
+define('ADMWSWP_VERSION', '1.6.4');
 define('ADMWSWP_TEXTDOMAIN', 'admwswp');
 define('ADMWSWP_PLUGIN_NAME', 'administrate-wp-weblink-plugin/admwswp.php');
 // List of plugins separated by comas.

--- a/public/class-admwswp-public.php
+++ b/public/class-admwswp-public.php
@@ -388,7 +388,7 @@ class Admwswp_Public
         ];
         $weblinkMountArgs = apply_filters('admwswp_weblink_args', $weblinkMountArgs);
         if ($configuration !== '') {
-            $configuration = str_replace(["&#091;", "&#093;"], ["[", "]"], $configuration);
+            $configuration = str_replace(["&#091;", "&#093;", "&#39;", "&"], ["[", "]", "'", "&amp;"], $configuration);
             $decodedConfiguration = json_decode($configuration, true);
 
             if ($decodedConfiguration['links'] || !$product_route) {
@@ -414,7 +414,7 @@ class Admwswp_Public
         $html .= "});";
         $html .= "clearInterval(weblinkInterval$widgetId); } }, 500);"; // interval ending
         $html .= "</script>";
-        
+
         if ($showAddToCart) {
             return $html;
         }


### PR DESCRIPTION
Similar to https://github.com/Administrate/administrate-wp-weblink-plugin/pull/49 we need to replace single quotes with their ASCII equivalent to allow parsing the configuration correctly, otherwise the Wordpress shortcode exits early.

Also replace `&` with `&amp;` to work around a bug in Wordpress/WPTexturize where `&` was being converted to `&#038;` outwith our control.

https://administrate.atlassian.net/browse/PLAT-24526